### PR TITLE
s/licence/license/g

### DIFF
--- a/lib/camel/camel.h
+++ b/lib/camel/camel.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Camel testing framework, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/camel/src/camel.c
+++ b/lib/camel/src/camel.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Camel testing framework, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/netlibc/include/netlibc.h
+++ b/lib/netlibc/include/netlibc.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of netlibc, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/netlibc/src/error.c
+++ b/lib/netlibc/src/error.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of netlibc, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/netlibc/src/fs.c
+++ b/lib/netlibc/src/fs.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of netlibc, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/netlibc/src/log.c
+++ b/lib/netlibc/src/log.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of netlibc, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/netlibc/src/netlibc.c
+++ b/lib/netlibc/src/netlibc.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of netlibc, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/netlibc/src/string.c
+++ b/lib/netlibc/src/string.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of netlibc, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/include/sonic.h
+++ b/lib/shogdb/include/sonic.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/src/db/db.c
+++ b/lib/shogdb/src/db/db.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/src/db/db.h
+++ b/lib/shogdb/src/db/db.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/src/db/dht.c
+++ b/lib/shogdb/src/db/dht.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/src/db/dht.h
+++ b/lib/shogdb/src/db/dht.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/src/db/pins.c
+++ b/lib/shogdb/src/db/pins.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/src/db/pins.h
+++ b/lib/shogdb/src/db/pins.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/src/hashmap/hashmap.c
+++ b/lib/shogdb/src/hashmap/hashmap.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/src/hashmap/hashmap.h
+++ b/lib/shogdb/src/hashmap/hashmap.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/src/lib/lib.c
+++ b/lib/shogdb/src/lib/lib.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/src/lib/lib.h
+++ b/lib/shogdb/src/lib/lib.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/shogdb/src/main.c
+++ b/lib/shogdb/src/main.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/sonic/include/camel.h
+++ b/lib/sonic/include/camel.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Camel testing framework, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/sonic/include/client.h
+++ b/lib/sonic/include/client.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/sonic/include/server.h
+++ b/lib/sonic/include/server.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/sonic/include/utils.h
+++ b/lib/sonic/include/utils.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/sonic/sonic.h
+++ b/lib/sonic/sonic.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/sonic/src/client/client.c
+++ b/lib/sonic/src/client/client.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/sonic/src/server/rate_limiter.c
+++ b/lib/sonic/src/server/rate_limiter.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/sonic/src/server/rate_limiter.h
+++ b/lib/sonic/src/server/rate_limiter.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/sonic/src/server/server.c
+++ b/lib/sonic/src/server/server.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/sonic/src/sonic.c
+++ b/lib/sonic/src/sonic.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/sonic/src/utils.c
+++ b/lib/sonic/src/utils.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/tuwi/src/tuwi.c
+++ b/lib/tuwi/src/tuwi.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Tuwi framework, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/lib/tuwi/tuwi.h
+++ b/lib/tuwi/tuwi.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Tuwi framework, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/args/args.c
+++ b/src/args/args.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/args/args.h
+++ b/src/args/args.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/const.h
+++ b/src/const.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/docs/md/docs.md
+++ b/src/docs/md/docs.md
@@ -534,7 +534,7 @@ If you encounter any bugs or need assistance with anything, do not hesitate to j
 
 Shoggoth is licensed under the MIT license. Read the LICENSE file in the source code for more information
 
-Shoggoth uses a few dependencies which have their own licences. The dependencies in the ./lib/ directory of the Shoggoth source code are independent of the MIT license used for Shoggoth.
+Shoggoth uses a few dependencies which have their own licenses. The dependencies in the ./lib/ directory of the Shoggoth source code are independent of the MIT license used for Shoggoth.
 The source code for each dependecy includes a LICENSE file indicating the license that covers it.
 
 ### Community

--- a/src/include/camel.h
+++ b/src/include/camel.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Camel testing framework, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/include/shogdb.h
+++ b/src/include/shogdb.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the ShogDB database, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/include/sonic.h
+++ b/src/include/sonic.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 ShogAI - https://shog.ai
  *
  * Part of the Sonic HTTP library, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/include/tuwi.h
+++ b/src/include/tuwi.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Tuwi framework, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/json/json.c
+++ b/src/json/json.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/json/json.h
+++ b/src/json/json.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/main.c
+++ b/src/main.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/db/db.c
+++ b/src/node/db/db.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/db/db.h
+++ b/src/node/db/db.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/dht/dht.c
+++ b/src/node/dht/dht.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/dht/dht.h
+++ b/src/node/dht/dht.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/manifest/manifest.c
+++ b/src/node/manifest/manifest.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/manifest/manifest.h
+++ b/src/node/manifest/manifest.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/node.h
+++ b/src/node/node.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/og/og.c
+++ b/src/node/og/og.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/og/og.h
+++ b/src/node/og/og.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/pins/pins.c
+++ b/src/node/pins/pins.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/pins/pins.h
+++ b/src/node/pins/pins.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/server/api.c
+++ b/src/node/server/api.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/server/api.h
+++ b/src/node/server/api.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/server/server.c
+++ b/src/node/server/server.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/server/server.h
+++ b/src/node/server/server.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/server/server_explorer.c
+++ b/src/node/server/server_explorer.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/node/server/server_explorer.h
+++ b/src/node/server/server_explorer.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/openssl/openssl.c
+++ b/src/openssl/openssl.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/openssl/openssl.h
+++ b/src/openssl/openssl.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/templating/templating.c
+++ b/src/templating/templating.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/templating/templating.h
+++ b/src/templating/templating.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/toml/toml.c
+++ b/src/toml/toml.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/toml/toml.h
+++ b/src/toml/toml.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -3,7 +3,7 @@
  *  Copyright (c) 2023 Shoggoth Systems
  *
  * Part of the Shoggoth project, under the MIT License.
- * See LICENCE file for license information.
+ * See LICENSE file for license information.
  * SPDX-License-Identifier: MIT
  *
  ****/


### PR DESCRIPTION
I'm assuming the appearances of "LICENCE" are a typo b/c of the actual root folder filename and other occurrences of "license" - fixed all here.